### PR TITLE
Apply the changes in foundry-keystore to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ yarn global add foundry-keystore-cli
   Options:
 
     -V, --version                      output the version number
-    -t, --account-type <accountType>   'platform' or 'asset'. The type of the key (default: platform)
     --keys-path <keysPath>             the path to store the keys (default: keystore.db)
     --network-id <networkId>           the id of the network (use 'cc' for mainnet, use 'wc' for corgi) (default: cc)
     -h, --help                         output usage information
@@ -39,20 +38,20 @@ yarn global add foundry-keystore-cli
     create [options]                   create a new key
     delete [options]                   delete a key
     import [options] <path>            import a key
-    import-raw [options] <privateKey>  import a raw private key (32 byte hexadecimal string)
+    import-raw [options] <privateKey>  import a raw private key (64 byte hexadecimal string)
     export [options]                   export the key
 
   Examples:
 
-    cckey create -t platform --passphrase "my password"
+    cckey create --passphrase "passphrase1"
 
-    cckey list -t asset
+    cckey list
 
-    cckey delete -t platform --address "ccc..."
+    cckey delete --address cccqy6vhjxs8ddf6y6etgdqcs5elcrl6n6t0vdwumu8
 
-    cckey import UTC--2018-08-14T06-30-23Z--bbb6685e-7165-819d-0988-fc1a7d2d0523 -t platform --passphrase "satoshi"
+    cckey import UTC--2020-03-05T02-47-14Z--6adba8c6-04ff-f649-6347-5c7946e28733 --passphrase "passphrase2"
 
-    cckey export -t platform --address cccq8ah0efv5ckpx6wy5mwva2aklzwsdw027sqfksrr --passphrase "satoshi"
+    cckey export --address cccq8ah0efv5ckpx6wy5mwva2aklzwsdw027sqfksrr --passphrase "passphrase3"
 
-    cckey import-raw -t platform a05f81608217738d99da8fd227897b87e8890d3c9159b559c7c8bbd408e5fb6e --passphrase "satoshi"
+    cckey import-raw b71f1a9a5fb62155b7ccc12841867e95a33da91c30515804546c7c5e575f2048287dec3980387a12ef9f159721c853e47e64a37f61407e0231ee62983cd6d2e --passphrase "passphrase4"
 ```

--- a/build-binaries
+++ b/build-binaries
@@ -13,9 +13,9 @@ execSync("yarn pkg -t node12-linux-x64,node12-macos-x64,node12-win-x64 --out-pat
 console.log("Build done");
 
 const files = [
-    "codechain-keystore-cli-linux",
-    "codechain-keystore-cli-macos",
-    "codechain-keystore-cli-win.exe"
+    "foundry-keystore-cli-linux",
+    "foundry-keystore-cli-macos",
+    "foundry-keystore-cli-win.exe"
 ];
 
 process.chdir("binaries");

--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
     "typescript": "^3.0.1"
   },
   "dependencies": {
-    "codechain-keystore": "^0.6.3",
-    "codechain-primitives": "^1.0.4",
     "commander": "^2.17.1",
     "enquirer": "^2.3.1",
+    "foundry-keystore": "^0.1.0",
+    "foundry-primitives": "^0.2.1",
     "lodash": "^4.17.14"
   }
 }

--- a/src/command/create.ts
+++ b/src/command/create.ts
@@ -2,12 +2,12 @@ import { Context } from "../types";
 import { getAddressFromKey } from "../util";
 
 export async function createKey(
-    { cckey, accountType, networkId }: Context,
+    { cckey, networkId }: Context,
     passphrase: string
 ): Promise<void> {
-    const key = await cckey[accountType].createKey({
+    const key = await cckey.keystore.createKey({
         passphrase
     });
 
-    console.log(getAddressFromKey(accountType, key, networkId));
+    console.log(getAddressFromKey(key, networkId));
 }

--- a/src/command/delete.ts
+++ b/src/command/delete.ts
@@ -5,11 +5,11 @@ import { Context } from "../types";
 import { findMatchingKey } from "../util";
 
 export async function deleteKey(
-    { cckey, accountType, networkId }: Context,
+    { cckey, networkId }: Context,
     address: string
 ): Promise<void> {
-    const keys = await cckey[accountType].getKeys();
-    const key = findMatchingKey(accountType, keys, address, networkId);
+    const keys = await cckey.keystore.getKeys();
+    const key = findMatchingKey(keys, address, networkId);
 
     const question = {
         type: "confirm",
@@ -19,7 +19,7 @@ export async function deleteKey(
 
     const answer: any = await prompt(question);
     if (answer.delete) {
-        const result = await cckey[accountType].deleteKey({ key });
+        const result = await cckey.keystore.deleteKey({ key });
         if (!result) {
             throw new CLIError(CLIErrorType.Unknown, {
                 message: "Delete failed"

--- a/src/command/export.ts
+++ b/src/command/export.ts
@@ -1,16 +1,16 @@
-import { SecretStorage } from "codechain-keystore";
+import { SecretStorage } from "foundry-keystore";
 
 import { Context } from "../types";
 import { findMatchingKey } from "../util";
 
 export async function exportKey(
-    { cckey, accountType, networkId }: Context,
+    { cckey, networkId }: Context,
     address: string,
     passphrase: string
 ): Promise<SecretStorage> {
-    const keys = await cckey[accountType].getKeys();
-    const key = findMatchingKey(accountType, keys, address, networkId);
-    return cckey[accountType].exportKey({
+    const keys = await cckey.keystore.getKeys();
+    const key = findMatchingKey(keys, address, networkId);
+    return cckey.keystore.exportKey({
         key,
         passphrase
     });

--- a/src/command/import.ts
+++ b/src/command/import.ts
@@ -1,17 +1,17 @@
-import { SecretStorage } from "codechain-keystore";
+import { SecretStorage } from "foundry-keystore";
 
 import { Context } from "../types";
 import { getAddressFromKey } from "../util";
 
 export async function importKey(
-    { cckey, accountType, networkId }: Context,
+    { cckey, networkId }: Context,
     secret: SecretStorage,
     passphrase: string
 ): Promise<void> {
-    const key = await cckey[accountType].importKey({
+    const key = await cckey.keystore.importKey({
         secret,
         passphrase
     });
 
-    console.log(getAddressFromKey(accountType, key, networkId));
+    console.log(getAddressFromKey(key, networkId));
 }

--- a/src/command/importRaw.ts
+++ b/src/command/importRaw.ts
@@ -1,17 +1,17 @@
-import { PrivateKey } from "codechain-keystore/lib/types";
+import { PrivateKey } from "foundry-keystore/lib/types";
 
 import { Context } from "../types";
 import { getAddressFromKey } from "../util";
 
 export async function importRawKey(
-    { cckey, accountType, networkId }: Context,
+    { cckey, networkId }: Context,
     privateKey: PrivateKey,
     passphrase: string
 ): Promise<void> {
-    const key = await cckey[accountType].importRaw({
+    const key = await cckey.keystore.importRaw({
         privateKey,
         passphrase
     });
 
-    console.log(getAddressFromKey(accountType, key, networkId));
+    console.log(getAddressFromKey(key, networkId));
 }

--- a/src/command/list.ts
+++ b/src/command/list.ts
@@ -3,13 +3,9 @@ import * as _ from "lodash";
 import { Context } from "../types";
 import { getAddressFromKey } from "../util";
 
-export async function listKeys({
-    cckey,
-    accountType,
-    networkId
-}: Context): Promise<void> {
-    let keys = await cckey[accountType].getKeys();
-    keys = _.map(keys, key => getAddressFromKey(accountType, key, networkId));
+export async function listKeys({ cckey, networkId }: Context): Promise<void> {
+    let keys = await cckey.keystore.getKeys();
+    keys = _.map(keys, key => getAddressFromKey(key, networkId));
     if (keys.length === 0) {
         console.log("");
     } else {

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,7 +1,6 @@
 import { Action } from "./types";
 
 export enum CLIErrorType {
-    InvalidAccountType,
     InvalidAction,
     InvalidAddress,
     OptionRequired,
@@ -19,8 +18,6 @@ function getErrorMessage(type: CLIErrorType, args: any = {}) {
     const actions: Action[] = ["list", "create", "delete"];
 
     switch (type) {
-        case CLIErrorType.InvalidAccountType:
-            return "Account-type should be 'platform' or 'asset'";
         case CLIErrorType.InvalidAction:
             return `Action should one of the ${JSON.stringify(actions)}`;
         case CLIErrorType.InvalidAddress:

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,8 @@
-import { CCKey } from "codechain-keystore";
+import { CCKey } from "foundry-keystore";
 
-export type AccountType = "platform" | "asset";
 export type Action = "list" | "create" | "delete";
 
 export interface CommonOption {
-    accountType: string;
     keysPath: string;
     networkId: string;
 }
@@ -37,6 +35,5 @@ export interface ExportOption {
 
 export interface Context {
     cckey: CCKey;
-    accountType: AccountType;
     networkId: string;
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,39 +1,22 @@
-import { Key } from "codechain-keystore/lib/types";
-import { AssetAddress, PlatformAddress } from "codechain-primitives";
+import { Key } from "foundry-keystore/lib/types";
+import { Address } from "foundry-primitives";
 import * as _ from "lodash";
 
 import { CLIError, CLIErrorType } from "./error";
-import { AccountType } from "./types";
 
-export function getAddressFromKey(
-    accountType: AccountType,
-    key: Key,
-    networkId: string
-): string {
-    if (accountType === "platform") {
-        const platformAddress = PlatformAddress.fromAccountId(key, {
-            networkId
-        });
-        return platformAddress.toString();
-    } else if (accountType === "asset") {
-        const assetAddress = AssetAddress.fromTypeAndPayload(1, key, {
-            networkId
-        });
-        return assetAddress.toString();
-    } else {
-        throw new CLIError(CLIErrorType.InvalidAccountType);
-    }
+export function getAddressFromKey(key: Key, networkId: string): string {
+    const address = Address.fromAccountId(key, {
+        networkId
+    });
+    return address.toString();
 }
 
 export function findMatchingKey(
-    accountType: AccountType,
     keys: Key[],
     address: string,
     networkId: string
 ): string {
-    const addresses = _.map(keys, key =>
-        getAddressFromKey(accountType, key, networkId)
-    );
+    const addresses = _.map(keys, key => getAddressFromKey(key, networkId));
     const index = _.indexOf(addresses, address);
     if (index === -1) {
         throw new CLIError(CLIErrorType.NoSuchAddress, { address });

--- a/yarn.lock
+++ b/yarn.lock
@@ -173,12 +173,6 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
-base-x@^3.0.2:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.4.tgz#94c1788736da065edb1d68808869e357c977fa77"
-  dependencies:
-    safe-buffer "^5.0.1"
-
 base64-js@^1.0.2:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
@@ -201,41 +195,15 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-bech32@=1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.3.tgz#bd47a8986bbb3eec34a56a097a84b8d3e9a2dfcd"
-  integrity sha512-yuVFUvrNcoJi0sv5phmqc6P+Fl1HjRDRNOOkHY2X/3LBy2bIGNSFx4fZ95HMaXHupuS7cZR15AsvtmCIF4UEyg==
-
 bignumber.js@^7.2.1:
   version "7.2.1"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-7.2.1.tgz#80c048759d826800807c4bfd521e50edbba57a5f"
-
-bitcore-lib@^8.6.0:
-  version "8.6.0"
-  resolved "https://registry.yarnpkg.com/bitcore-lib/-/bitcore-lib-8.6.0.tgz#d7fc7c1815916f2914a3feb04227d5d10830e0d5"
-  integrity sha512-fEMx2WeHRQGaGy72CBO8RQu7Eunl2MgUfrBVEOVX2qcQtfvtYTVE4KK7L7CPlJcD8YUPZYaWKOMBTVBiB8B8Bg==
-  dependencies:
-    bech32 "=1.1.3"
-    bn.js "=4.11.8"
-    bs58 "^4.0.1"
-    buffer-compare "=1.1.1"
-    elliptic "=6.4.0"
-    inherits "=2.0.1"
-    lodash "=4.17.15"
-
-bitcore-mnemonic@^8.6.0:
-  version "8.6.0"
-  resolved "https://registry.yarnpkg.com/bitcore-mnemonic/-/bitcore-mnemonic-8.6.0.tgz#c9c4579bbb812a5cfee956cb1c65ec5157304aea"
-  integrity sha512-/I3MxFIAwlVCHeJE3wPmiF1hHivr8TXOD6feeURDx8F0c6xpnWWpA6TRdxhZupYmnGYDXnhma4exJrMp3sEHmA==
-  dependencies:
-    bitcore-lib "^8.6.0"
-    unorm "^1.4.1"
 
 blakejs@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.1.0.tgz#69df92ef953aa88ca51a32df6ab1c54a155fc7a5"
 
-bn.js@=4.11.8, bn.js@^4.11.8, bn.js@^4.4.0:
+bn.js@^4.11.8, bn.js@^4.4.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
 
@@ -264,17 +232,6 @@ braces@^2.3.1:
 brorand@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
-
-bs58@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/bs58/-/bs58-4.0.1.tgz#be161e76c354f6f788ae4071f63f34e8c4f0a42a"
-  integrity sha1-vhYedsNU9veIrkBx9j806MTwpCo=
-  dependencies:
-    base-x "^3.0.2"
-
-buffer-compare@=1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/buffer-compare/-/buffer-compare-1.1.1.tgz#5be7be853af89198d1f4ddc090d1d66a48aef596"
 
 buffer-from@^1.0.0, buffer-from@^1.1.0:
   version "1.1.1"
@@ -343,35 +300,6 @@ class-utils@^0.3.5:
     define-property "^0.2.5"
     isobject "^3.0.0"
     static-extend "^0.1.1"
-
-codechain-keystore@^0.6.3:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/codechain-keystore/-/codechain-keystore-0.6.3.tgz#9042169dd03c9b67ff8e73253a009515dd1e58a5"
-  integrity sha512-bSUhuv9UIXoAKwSWhnylIhnU+BOypd7aqL0E8rPumS5qmsqUZgwMoKCfQBasCVpH+Hm+4fR0CSfVK/J7s/Hvfw==
-  dependencies:
-    bitcore-mnemonic "^8.6.0"
-    codechain-primitives "^1.0.0"
-    config "^2.0.1"
-    lodash "^4.17.10"
-    lowdb "^1.0.0"
-    lowdb-session-storage-adapter "^1.0.0"
-    uuid "^3.3.2"
-
-codechain-primitives@^1.0.0, codechain-primitives@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/codechain-primitives/-/codechain-primitives-1.0.4.tgz#26918fc5229c3fa0cc8c2d6ecda1ad3740292a4a"
-  integrity sha512-BOA+NL/iHuzp05DC8vLxC2vIMvIHPzREH4sgwcrQKKsnvTMf5frVdBQKBWl6Me2A4M7aa6T+wDe6pAD3WEoJ3w==
-  dependencies:
-    bignumber.js "^7.2.1"
-    blakejs "^1.1.0"
-    bn.js "^4.11.8"
-    buffer "^5.2.1"
-    crypto-js "^3.1.9-1"
-    elliptic "^6.4.1"
-    hmac-drbg "^1.0.1"
-    lodash "^4.17.14"
-    node-forge "^0.7.6"
-    rlp "^2.1.0"
 
 collection-visit@^1.0.0:
   version "1.0.0"
@@ -488,18 +416,6 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
-
-elliptic@=6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.4.0.tgz#cac9af8762c85836187003c8dfe193e5e2eae5df"
-  dependencies:
-    bn.js "^4.4.0"
-    brorand "^1.0.1"
-    hash.js "^1.0.0"
-    hmac-drbg "^1.0.0"
-    inherits "^2.0.1"
-    minimalistic-assert "^1.0.0"
-    minimalistic-crypto-utils "^1.0.0"
 
 elliptic@^6.4.1:
   version "6.4.1"
@@ -658,6 +574,35 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
+
+foundry-keystore@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/foundry-keystore/-/foundry-keystore-0.1.0.tgz#d1d85f42e3b578bfbd2f653b036d5734d76a19f2"
+  integrity sha512-LUUPDpysjl6Bh0/FpW/Xz7eSsNBRMoaA3e/CY/lTRpfd/+dRwH7MxruDXtKS82UgTxvxjQOgKWHdEVei2nKMiw==
+  dependencies:
+    config "^2.0.1"
+    foundry-primitives "^0.2.1"
+    lodash "^4.17.10"
+    lowdb "^1.0.0"
+    lowdb-session-storage-adapter "^1.0.0"
+    uuid "^3.3.2"
+
+foundry-primitives@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/foundry-primitives/-/foundry-primitives-0.2.1.tgz#287f35d7179905f10e87ac71dc4acc5636f41437"
+  integrity sha512-q/m/08djWYMfaZWddCz6QVL6tEcCzyJyigQOmUZDS8WIuT6mVF60fpewpxhy892F/E+hEl8mgE5iutgXf74lbg==
+  dependencies:
+    bignumber.js "^7.2.1"
+    blakejs "^1.1.0"
+    bn.js "^4.11.8"
+    buffer "^5.2.1"
+    crypto-js "^3.1.9-1"
+    elliptic "^6.4.1"
+    hmac-drbg "^1.0.1"
+    lodash "^4.17.14"
+    node-forge "^0.7.6"
+    rlp "^2.1.0"
+    tweetnacl "^1.0.3"
 
 fragment-cache@^0.2.1:
   version "0.2.1"
@@ -833,10 +778,6 @@ inflight@^1.0.4:
 inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
-
-inherits@=2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
 
 into-stream@~5.1.0:
   version "5.1.0"
@@ -1040,11 +981,6 @@ lodash@4, lodash@^4.17.10, lodash@^4.17.14:
   version "4.17.14"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
   integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
-
-lodash@=4.17.15:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 lowdb-session-storage-adapter@^1.0.0:
   version "1.0.0"
@@ -1700,6 +1636,11 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
 
+tweetnacl@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.3.tgz#ac0af71680458d8a6378d0d0d050ab1407d35596"
+  integrity sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==
+
 type-check@~0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
@@ -1735,11 +1676,6 @@ unique-temp-dir@~1.0.0:
 universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
-
-unorm@^1.4.1:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/unorm/-/unorm-1.6.0.tgz#029b289661fba714f1a9af439eb51d9b16c205af"
-  integrity sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==
 
 unset-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
[foundry-primitives@0.2.1](https://www.npmjs.com/package/foundry-primitives) and [foundry-keystore@0.1.0](https://www.npmjs.com/package/foundry-keystore) were published.
We removed the unnecessary Asset type from them and renamed the Platform type to 'keystore'. Therefore, there is no keytype in the renewed keystore. In addition, they use the Ed25519 signature, which uses a 64 byte private key.

To apply the changes in foundry-keystore and primitives to foundry-cli, we removed the concept of accountType, renamed it to 'keystore' and changed the 32 byte private key to 64 bytes.
